### PR TITLE
Allow ptb to be used as a module

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,7 +51,14 @@ You can also install from git repo
 Usage
 ~~~~~
 
-Just add this line at the top of your script
+Test your existing script without editing it:
+
+::
+
+    python -m ptb my_script
+
+
+Or just add this line at the top of your script
 
 ::
 

--- a/ptb/__main__.py
+++ b/ptb/__main__.py
@@ -1,0 +1,26 @@
+import os
+import sys
+import ptb
+
+ptb.enable()
+
+# Check that a script was passed in.
+if len(sys.argv) <= 1:
+    raise SystemExit("Usage: python -m ptb my_script.py")
+
+# Check that the script exists.
+script_path = sys.argv[1]
+if not os.path.exists(script_path):
+    raise SystemExit("Error: '%s' does not exist" % script_path)
+
+# Replace ptb's dir with script's dir in the module search path.
+sys.path[0] = os.path.dirname(script_path)
+
+# Remove ptb from the arg list.
+del sys.argv[0]
+
+with open(script_path) as script_file:
+    code = compile(script_file.read(), script_path, 'exec')
+    variables = {}
+    exec(code, variables, variables)
+


### PR DESCRIPTION
This code is inspired by the one in [colored-traceback](https://github.com/staticshock/colored-traceback.py/blob/master/colored_traceback/__main__.py). It allows ptb to be launched with `python -m ptb somescript.py`, so anyone can test it without editing any code.